### PR TITLE
Fix call to render to include mandatory argument

### DIFF
--- a/demos/play.py
+++ b/demos/play.py
@@ -79,7 +79,7 @@ def main(env, policy_names, param_versions, max_episodes):
     observation = env.reset()
     print("-" * 5 + "Episode %d " % (num_episodes + 1) + "-" * 5)
     while num_episodes < max_episodes:
-        env.render()
+        env.render(mode='human')
         action = tuple([
             pi.act(stochastic=True, observation=observation[i])[0]
             for i, pi in enumerate(policy)


### PR DESCRIPTION
First of all, I don't really know Python, so apologies if there's a better way of doing this.

Inspecting the render method in the call being modified by this PR yields:

`    def render(mode):
        return env._render(mode, close=False)
`
I'm not sure where it's defined, but it has the mode argument as mandatory instead of optional, so I made this change. I can only assume that the gym package was on an older version when this was released initially?